### PR TITLE
DAVPTA-729 New Neos 7.2 NodeType File Structure Compatibility

### DIFF
--- a/Classes/Service/NodeTypeService.php
+++ b/Classes/Service/NodeTypeService.php
@@ -4,8 +4,7 @@ namespace CRON\NeosTranslationUtils\Service;
 
 use CRON\NeosTranslationUtils\Service\Model\NodeType;
 use CRON\NeosTranslationUtils\Utils\FileUtils;
-use /** @noinspection PhpUnusedAliasInspection */
-    Neos\Flow\Annotations as Flow;
+use Neos\Flow\Annotations as Flow;
 
 use Symfony\Component\Yaml\Parser as YamlParser;
 
@@ -126,10 +125,18 @@ class NodeTypeService
 
         $translationKeys = $this->processTranslationIdExceptions($this->extractTranslationKeys($yamlValues));
 
-        // split filename into parts by '.' and remove the .yaml-ending
-        $filePathParts = explode('/', $filePath);
-        $fileName = $filePathParts[count($filePathParts) - 1];
-        $fileNameParts = explode('.', preg_replace('/\.yaml$/', '', $fileName));
+        // determine the path/filename parts of the translation file to be created for this NodeType.
+        // A NodeType like 'Vendor.Package:Content.Division.ComponentName' should yield a translation file
+        // Content/Division/ComponentName.xlf in the NodeTypes directory of the locale.
+        $nodeTypeFullNames = array_keys($yamlValues);
+
+        if (count($nodeTypeFullNames) > 0) {
+            $nodeTypeFullName = $nodeTypeFullNames[0];
+        } else {
+            return null;
+        }
+
+        $fileNameParts = explode('.', explode(':', $nodeTypeFullName)[1]);
 
         return new NodeType($filePath, $fileNameParts, $translationKeys);
     }

--- a/Classes/Service/NodeTypeService.php
+++ b/Classes/Service/NodeTypeService.php
@@ -17,10 +17,10 @@ use Symfony\Component\Yaml\Parser as YamlParser;
 class NodeTypeService
 {
     /**
-     * @Flow\InjectConfiguration(path="nodeTypes.includePattern")
-     * @var string
+     * @Flow\InjectConfiguration(path="nodeTypes.includePatterns")
+     * @var array
      */
-    protected $includePattern;
+    protected $includePatterns;
 
     /**
      * @Flow\InjectConfiguration(path="nodeTypes.translationMagicValue")
@@ -49,11 +49,17 @@ class NodeTypeService
      * Return the absolute paths of the included NodeType files.
      *
      * @param string $basePath
-     * @return array|null
+     * @return array
      */
     protected function getNodeTypeFilePaths($basePath)
     {
-        return $this->fileUtils->globFiles($basePath, $this->includePattern);
+        $nodeTypeFilePaths = [];
+
+        foreach ($this->includePatterns as $includePattern) {
+            $nodeTypeFilePaths = array_merge($nodeTypeFilePaths, $this->fileUtils->globFiles($basePath, $includePattern));
+        }
+
+        return $nodeTypeFilePaths;
     }
 
     /**
@@ -139,10 +145,6 @@ class NodeTypeService
     public function getNodeTypes($basePath)
     {
         $nodeTypeFilePaths = $this->getNodeTypeFilePaths($basePath);
-
-        if ($nodeTypeFilePaths == null) {
-            return null;
-        }
 
         $nodeTypeFiles = [];
 

--- a/Classes/Service/XliffTranslationService.php
+++ b/Classes/Service/XliffTranslationService.php
@@ -232,7 +232,7 @@ class XliffTranslationService
      */
     protected function buildXliffTranslationFilePath($basePath, $locale, $pathParts)
     {
-        return implode('/', [rtrim($basePath, '/'), trim($this->translationsPath, '/'), $locale, implode('/', $pathParts)]) . '.' . $this->translationFileExtension;
+        return implode('/', [rtrim($basePath, '/'), trim($this->translationsPath, '/'), $locale, 'NodeTypes', implode('/', $pathParts)]) . '.' . $this->translationFileExtension;
     }
 
     /**

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -1,7 +1,9 @@
 CRON:
   NeosTranslationUtils:
     nodeTypes:
-      includePattern: 'Configuration/NodeTypes.*.yaml'
+      includePatterns:
+        - 'Configuration/NodeTypes.*.yaml'
+        - 'NodeTypes/**/*.yaml'
       translationMagicValue: 'i18n'
     translations:
       path: 'Resources/Private/Translations'


### PR DESCRIPTION
This PR makes this package compatible with the new NodeType file structure supported by Neos 7.2 .
The old way for NodeType files like
`Configuration/NodeTypes.Content.MyComponent.yaml`
and the new way like
`NodeTypes/Content/MyComponent.yaml`
will be supported at the same time.