### PR TITLE
Update/Fix After Neos Update

### DIFF
--- a/Classes/Service/NodeTypeService.php
+++ b/Classes/Service/NodeTypeService.php
@@ -194,6 +194,10 @@ class NodeTypeService
                 return $matches[1];
             }
 
+            if (preg_match('/^ui\\.inspector\\.(tabs\\.[^\\.]+)\\.label$/', $translationId, $matches)) {
+                return $matches[1];
+            }
+
             if (preg_match('/^properties\\.([^\\.]+)\\.ui\\.inspector\\.editorOptions\\.values\\.([^\\.]+)\\.label$/', $translationId, $matches)) {
                 return 'properties.' . $matches[1] .'.selectBoxEditor.values.' . $matches[2];
             }

--- a/Classes/Service/NodeTypeService.php
+++ b/Classes/Service/NodeTypeService.php
@@ -136,7 +136,11 @@ class NodeTypeService
             return null;
         }
 
-        $fileNameParts = explode('.', explode(':', $nodeTypeFullName)[1]);
+        // before ':' is the package key, if existent
+        // after ':' is the NodeType name
+        $nodeTypeFullNameSplit = explode(':', $nodeTypeFullName);
+
+        $fileNameParts = explode('.', $nodeTypeFullNameSplit[array_key_last($nodeTypeFullNameSplit)]);
 
         return new NodeType($filePath, $fileNameParts, $translationKeys);
     }


### PR DESCRIPTION
This PR fixes the logic for NodeTypes that do not have a package key prefix, like `NodeTypes.Mixin.MyMixin` instead of `Vendor.Package:NodeTypes.Mixin.MyMixin`.

This PR also updates the RegEx patterns to include the special case of tabs.